### PR TITLE
Fix CI action for setting up Rust

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -11,9 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Rust
-        uses: actions/setup-rust@v2
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
+          toolchain: stable
+          override: true
       - name: Install tooling
         run: |
           brew install create-dmg


### PR DESCRIPTION
## Summary
- fix GitHub Actions workflow step for setting up Rust

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684c32612d14832296732a99b786ff5e