### PR TITLE
Fix DMG build step

### DIFF
--- a/.github/workflows/macos-dmg.yml
+++ b/.github/workflows/macos-dmg.yml
@@ -11,9 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Rust
-        uses: actions/setup-rust@v2
+        uses: actions-rs/toolchain@v1
         with:
-          rust-version: stable
+          toolchain: stable
+          override: true
       - name: Install tooling
         run: |
           brew install create-dmg
@@ -24,7 +25,7 @@ jobs:
         run: cargo bundle --release
       - name: Create DMG
         run: |
-          create-dmg --overwrite target/release/bundle/osx/AutoClicker.app
+          create-dmg target/release/bundle/osx/AutoClicker.app AutoClicker.dmg
       - name: Upload DMG artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To create a macOS DMG locally you can install `cargo-bundle` and `create-dmg`:
 brew install create-dmg
 cargo install cargo-bundle
 cargo bundle --release
-create-dmg target/release/bundle/osx/AutoClicker.app
+create-dmg target/release/bundle/osx/AutoClicker.app AutoClicker.dmg
 ```
 
 A GitHub Actions workflow builds the DMG automatically whenever a tag starting with `v` is pushed.


### PR DESCRIPTION
## Summary
- update `create-dmg` invocation to specify output file
- clarify local instructions in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684c32612d14832296732a99b786ff5e