### PR TITLE
Make tray icon macOS only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,6 @@ eframe = "0.31"
 enigo = "0.5"
 device_query = "3"
 crossbeam-channel = "0.5"
+
+[target.'cfg(target_os = "macos")'.dependencies]
 tray-icon = "0.20"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,12 @@
 use crossbeam_channel::Receiver;
 use eframe::{egui, App, Frame, NativeOptions};
-use tray_icon::{menu::{Menu, MenuItem, MenuEvent}, TrayIconBuilder, Icon};
 use std::time::Duration;
+
+#[cfg(target_os = "macos")]
+use tray_icon::{menu::{Menu, MenuItem, MenuEvent}, TrayIconBuilder, Icon};
+
+#[cfg(not(target_os = "macos"))]
+compile_error!("This crate currently only supports macOS targets.");
 
 mod auto_clicker;
 use auto_clicker::{AutoClicker, Config, Rect};
@@ -112,25 +117,28 @@ fn main() -> eframe::Result<()> {
         }
     });
 
-    // tray icon with quit menu
-    let mut tray_menu = Menu::new();
-    let quit_item = MenuItem::new("Quit", true, None);
-    let _ = tray_menu.append(&quit_item);
-    let icon = Icon::from_rgba(vec![0, 0, 0, 0], 1, 1).unwrap();
-    let _tray = TrayIconBuilder::new()
-        .with_menu(Box::new(tray_menu))
-        .with_tooltip("AutoClicker")
-        .with_icon(icon)
-        .build()
-        .unwrap();
-    std::thread::spawn(move || {
-        let menu_rx = MenuEvent::receiver();
-        while let Ok(event) = menu_rx.recv() {
-            if event.id == quit_item.id() {
-                std::process::exit(0);
+    // tray icon with quit menu (only on macOS)
+    #[cfg(target_os = "macos")]
+    {
+        let mut tray_menu = Menu::new();
+        let quit_item = MenuItem::new("Quit", true, None);
+        let _ = tray_menu.append(&quit_item);
+        let icon = Icon::from_rgba(vec![0, 0, 0, 0], 1, 1).unwrap();
+        let _tray = TrayIconBuilder::new()
+            .with_menu(Box::new(tray_menu))
+            .with_tooltip("AutoClicker")
+            .with_icon(icon)
+            .build()
+            .unwrap();
+        std::thread::spawn(move || {
+            let menu_rx = MenuEvent::receiver();
+            while let Ok(event) = menu_rx.recv() {
+                if event.id == quit_item.id() {
+                    std::process::exit(0);
+                }
             }
-        }
-    });
+        });
+    }
 
     let app = AutoClickerApp::new(rx);
     let opts = NativeOptions::default();


### PR DESCRIPTION
## Summary
- restrict `tray-icon` to macOS
- guard tray icon code with `#[cfg(target_os="macos")]`
- emit a compile-time error for unsupported OSes

## Testing
- `cargo test --target x86_64-apple-darwin` *(fails: can't find crate for `core`)*

------
https://chatgpt.com/codex/tasks/task_e_684cf6b796108322ad8c25bfd8a2780a